### PR TITLE
Add more input validation to mixer component; prevents exception

### DIFF
--- a/Siren/Audio/UnityMixerComponent.cs
+++ b/Siren/Audio/UnityMixerComponent.cs
@@ -44,6 +44,11 @@ namespace Siren.Components
 		{
 			var waves = new List<WaveStream>();
 			if (!DA.GetDataList(0, waves)) return;
+			if (waves.Contains(null))
+            {
+				AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "An invalid wave input was provided; check for issues with earlier components.");
+				return;
+			}
 
 			var multiplier = 1 / waves.Count;
 			var mixer = new MixingSampleProvider(waves.Select(s => s.ToSampleProvider()));


### PR DESCRIPTION
A small suggested fix: line 49 of this file throws exceptions whenever null inputs are provided. This isn't necessarily a problem per se, but is slightly annoying when running Visual Studio in Debug as the exception will throw/interrupt when opening/closing files or otherwise messing with stuff upstream. The other components I've been using seem to fail silently.

Aside from preventing the exception, this adds a brief user-facing error message. I feel like validating Grasshopper inputs for nulls usually isn't particularly useful, but given the check I figure it's better to also provide some sort of human readable error rather than just let the exception itself be shown.